### PR TITLE
Fixes and improvements with tailoring pod and its linkables related to power

### DIFF
--- a/Source/VFEAncients/Comps/CompGeneTailoringPod.cs
+++ b/Source/VFEAncients/Comps/CompGeneTailoringPod.cs
@@ -149,7 +149,7 @@ namespace VFEAncients
                         Find.WindowStack.Add(new FloatMenu(options));
                     },
                     defaultLabel = "VFEAncients.StartOperation".Translate(),
-                    icon = StartOperationTex,
+                    icon = StartOperationTex
                 };
                 yield return new Command_Action
                 {

--- a/Source/VFEAncients/Comps/CompGeneTailoringPod.cs
+++ b/Source/VFEAncients/Comps/CompGeneTailoringPod.cs
@@ -26,8 +26,8 @@ namespace VFEAncients
             possibleOperations = typeof(Operation).AllSubclassesNonAbstract().Select(opType => (Operation) Activator.CreateInstance(opType, this)).ToList();
         }
 
-        public bool PowerOn => parent.GetComp<CompPowerTrader>().PowerOn;
-        public bool HasFuel => parent.GetComp<CompRefuelable>().HasFuel;
+        public bool PowerOn => !parent.TryGetComp<CompPowerTrader>(out var comp) || comp.PowerOn;
+        public bool HasFuel => !parent.TryGetComp<CompRefuelable>(out var comp) || comp.HasFuel;
 
         public Pawn Occupant => innerContainer.OfType<Pawn>().FirstOrDefault();
 
@@ -67,8 +67,16 @@ namespace VFEAncients
 
         public virtual void StartOperation(Operation op)
         {
+            // Check if operation still valid - handle situations where a machine was turned off with
+            // the start operation float menu open, allowing to still select the start operation option.
+            if (!op.CanRunOnPawn(Occupant))
+            {
+                Messages.Message("CannotUseReason".Translate("VFEAncient.AvailableOperationsCannotBeApplied".Translate()), parent, MessageTypeDefOf.RejectInput, false);
+                return;
+            }
+
             currentOperation = op;
-            parent.GetComp<CompRefuelable>().ConsumeFuel(1f);
+            parent.GetComp<CompRefuelable>()?.ConsumeFuel(1f);
             var allPods = parent.Map.listerThings.ThingsOfDef(parent.def);
 
             ticksTillDone = currentOperation.StartOnPawnGetDuration() + allPods.IndexOf(parent);
@@ -122,18 +130,26 @@ namespace VFEAncients
             {
                 yield return new Command_Action
                 {
-                    action = () => Find.WindowStack.Add(new FloatMenu(possibleOperations.Where(op => op.CanRunOnPawn(Occupant))
-                        .Select(op => new FloatMenuOption(op.Label,
-                            () => Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation("VFEAncients.ExperimentFailureWarning".Translate(
-                                    (Occupant?.GetPowerTracker()?.HasPower(VFEA_DefOf.PromisingCandidate) ?? false ? 0f : op.FailChanceOnPawn(Occupant)).ToStringPercent()
-                                    .Colorize(ColoredText.ThreatColor),
-                                    parent.def.GetCompProperties<CompProperties_AffectedByFacilities>().linkableFacilities.Where(def =>
-                                            def.GetCompProperties<CompProperties_Facility>()?.statOffsets?.Any(statMod => statMod.stat == VFEA_DefOf.VFEA_FailChance) ?? false)
-                                        .Select(def => def.label).ToLineList("  - "), op.TicksRequired.ToStringTicksToPeriodVerbose().Colorize(ColoredText.DateTimeColor),
-                                    TimeExplain, FailChanceExplain(op)),
-                                () => StartOperation(op), true)))).ToList())),
+                    action = () =>
+                    {
+                        var options = possibleOperations.Where(op => op.CanRunOnPawn(Occupant))
+                            .Select(op => new FloatMenuOption(op.Label,
+                                () => Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation("VFEAncients.ExperimentFailureWarning".Translate(
+                                        (Occupant?.GetPowerTracker()?.HasPower(VFEA_DefOf.PromisingCandidate) ?? false ? 0f : op.FailChanceOnPawn(Occupant)).ToStringPercent()
+                                        .Colorize(ColoredText.ThreatColor),
+                                        parent.def.GetCompProperties<CompProperties_AffectedByFacilities>().linkableFacilities.Where(def =>
+                                                def.GetCompProperties<CompProperties_Facility>()?.statOffsets?.Any(statMod => statMod.stat == VFEA_DefOf.VFEA_FailChance) ?? false)
+                                            .Select(def => def.label).ToLineList("  - "), op.TicksRequired.ToStringTicksToPeriodVerbose().Colorize(ColoredText.DateTimeColor),
+                                        TimeExplain, FailChanceExplain(op)),
+                                    () => StartOperation(op), true)))).ToList();
+                        // Handle situations where one of the machines was turned off after
+                        // a pawn entered the pod, ending in situation with no valid operations.
+                        if (!options.Any())
+                            options.Add(new FloatMenuOption("CannotUseReason".Translate("VFEAncient.AvailableOperationsCannotBeApplied".Translate()), null));
+                        Find.WindowStack.Add(new FloatMenu(options));
+                    },
                     defaultLabel = "VFEAncients.StartOperation".Translate(),
-                    icon = StartOperationTex
+                    icon = StartOperationTex,
                 };
                 yield return new Command_Action
                 {

--- a/Source/VFEAncients/Comps/Operation.cs
+++ b/Source/VFEAncients/Comps/Operation.cs
@@ -59,6 +59,7 @@ namespace VFEAncients
 
         public virtual int MaxPowerLevel =>
             Pod.parent.TryGetComp<CompAffectedByFacilities>().LinkedFacilitiesListForReading.OfType<ThingWithComps>().SelectMany(t => t.AllComps)
+                .Where(t => t.parent.IsPowered())
                 .Select(comp => comp.props)
                 .OfType<CompProperties_Facility_PowerUnlock>().Append(new CompProperties_Facility_PowerUnlock {unlockedLevels = 3})
                 .Sum(props => props.unlockedLevels);
@@ -81,7 +82,7 @@ namespace VFEAncients
                     "VFEAncients.Empowered.Text".Translate(tracker.Pawn.NameShortColored, powers.Item1.LabelCap, powers.Item2.LabelCap), LetterDefOf.PositiveEvent, tracker.Pawn);
             };
             GenDebug.LogList(Pod.parent.GetComp<CompAffectedByFacilities>().LinkedFacilitiesListForReading);
-            if (Pod.parent.GetComp<CompAffectedByFacilities>().LinkedFacilitiesListForReading.Any(t => t.def == VFEA_DefOf.VFEA_NaniteSampler))
+            if (Pod.parent.GetComp<CompAffectedByFacilities>().LinkedFacilitiesListForReading.Any(t => t.def == VFEA_DefOf.VFEA_NaniteSampler && t.IsPowered()))
                 Find.WindowStack.Add(new Dialog_ChoosePowers(new List<Tuple<PowerDef, PowerDef>>
                 {
                     new(superpowers.RandomElement(), weaknessess.RandomElement()),
@@ -104,7 +105,7 @@ namespace VFEAncients
 
         public override bool CanRunOnPawn(Pawn pawn)
         {
-            return base.CanRunOnPawn(pawn) && Pod.parent.GetComp<CompAffectedByFacilities>().LinkedFacilitiesListForReading.Any(t => t.def == VFEA_DefOf.VFEA_NanotechRetractor) &&
+            return base.CanRunOnPawn(pawn) && Pod.parent.GetComp<CompAffectedByFacilities>().LinkedFacilitiesListForReading.Any(t => t.def == VFEA_DefOf.VFEA_NanotechRetractor && t.IsPowered()) &&
                    pawn.GetPowerTracker().AllPowers.Any(power => power.powerType == PowerType.Weakness);
         }
 

--- a/Source/VFEAncients/Utils.cs
+++ b/Source/VFEAncients/Utils.cs
@@ -72,5 +72,10 @@ namespace VFEAncients
         {
             return input.Split('\n').Where(str => !str.NullOrEmpty()).Join(delimiter: "\n");
         }
+
+        public static bool IsPowered(this Thing thing)
+        {
+            return !thing.TryGetComp<CompPowerTrader>(out var comp) || comp.PowerOn;
+        }
     }
 }


### PR DESCRIPTION
Firstly, a few of the linkables that previously didn't need to be powered on need to be to work. If they either didn't have power or were turned off still worked. The linkables that didn't require power were the ones that allowed for extra powers, selection between 2 powers, and removal of weaknesses.

The check for power returns true if there's no `CompPowerTrader` to allow submods to add no power linkables or modify existing ones, mainly for mods aiming for a low tech/magical theme.

Second, `CompGeneTailoringPod` will now require power/fuel if `CompPowerTrader`/`CompRefuelable` are present. Won't change anything as it is right now, but will allow submods to give the pod a low tech/magical theme (or at least achieve it easier).

Third, `CompGeneTailoringPod` will now have extra safety around operations being unusable. The gizmo opening a float menu with list of operations will now return a disabled option informing of no valid operations (this will prevent errors related to opening float menu with no options). On top of that, `StartOperation` also checks if the operation is valid before proceeding further. This is to fix situations where a machine was turned off while the float menu was still open - in which case the option was still selectable.

The last part could have a slightly different approach - disabling the gizmo itself instead of showing a single disabled option for the float menu. The issue with it is that tooltip showing `disabledReason` for the gizmo expects a label to be present by having 2 empty lines before `disabledReason`. Since this gizmo doesn't have a label, it'll end up with 2 empty lines at the start of the tooltip.