### PR TITLE
Prevent ancients from being picked for distress signal

### DIFF
--- a/Source/VFEAncients/HarmonyPatches/QuestPatches.cs
+++ b/Source/VFEAncients/HarmonyPatches/QuestPatches.cs
@@ -2,6 +2,7 @@
 using RimWorld;
 using RimWorld.Planet;
 using System;
+using RimWorld.QuestGen;
 using Verse;
 
 namespace VFEAncients.HarmonyPatches
@@ -17,6 +18,8 @@ namespace VFEAncients.HarmonyPatches
                 typeof(SitePartDef), typeof(Faction), typeof(bool), typeof(Predicate<Faction>)
             ]),
             prefix: new HarmonyMethod(GetType(), nameof(FactionCanOwnPrefix)));
+            harm.Patch(AccessTools.Method(typeof(QuestNode_Root_DistressCall), nameof(QuestNode_Root_DistressCall.FactionUsable)),
+                prefix: new HarmonyMethod(FactionUsableForDistressCallPrefix));
         }
 
         public static bool FactionCanOwnPrefix(SitePartDef sitePart, Faction faction, ref bool __result)
@@ -24,6 +27,16 @@ namespace VFEAncients.HarmonyPatches
             if (faction != null && faction.def == VFEA_DefOf.VFEA_AncientSoldiers && sitePart.defName.StartsWith("VFEA_"))
             {
                 __result = true;
+                return false;
+            }
+            return true;
+        }
+
+        public static bool FactionUsableForDistressCallPrefix(Faction f, ref bool __result)
+        {
+            if (f != null && f.def == VFEA_DefOf.VFEA_AncientSoldiers)
+            {
+                __result = false;
                 return false;
             }
             return true;


### PR DESCRIPTION
Distress Signal quest/incident added by Anomaly has its own faction selection, which may end up picking ancient supersoldiers as the owner of the settlement. This fails and causes errors due to ancients not having a proper PawnGroupMakers for generating a settlement pawns.

The check made by the quest generation only looks for:
- Humanlike faction
- Has any PawnGroupMakers (doesn't check if it has correct ones)
- Is not a permanent enemy
- Special Empire handling we don't care about

There's not really anything in those parameters we can change to stop them from being picked (without causing further issues), so I've made a small Harmony patch to fix this issue.