### PR TITLE
Update supply slingshot trash handling

### DIFF
--- a/Source/VFEAncients/Comps/CompSupplySlingshot.cs
+++ b/Source/VFEAncients/Comps/CompSupplySlingshot.cs
@@ -7,6 +7,7 @@ using Verse;
 
 namespace VFEAncients;
 
+[StaticConstructorOnStartup]
 public class CompSupplySlingshot : ThingComp
 {
     private static ValueTuple<Map, Designator_Build> designator;
@@ -14,7 +15,21 @@ public class CompSupplySlingshot : ThingComp
 
     public CompTransporter Transporter => cachedCompTransporter ??= parent.GetComp<CompTransporter>();
 
-    public virtual int TicksToReturn => 60000 * 7;
+    public virtual int TicksToReturn => GenDate.TicksPerDay * 7;
+
+    // A dictionary that forces any item matching the key def to be returned back to the player,
+    // multiplied the value (so it can return more, less, or nothing back).
+    private static readonly Dictionary<ThingDef, float> ThingReturnCountMultiplier = new[]
+        {
+            // Return the same amount that was sent
+            (DefDatabase<ThingDef>.GetNamedSilentFail("VRecyclingE_ReclaimedBiopack"), 1f),
+            (DefDatabase<ThingDef>.GetNamedSilentFail("VRecyclingE_StabilizedAlloypack"), 1f),
+            // Return 5% extra trash when sending it back
+            (DefDatabase<ThingDef>.GetNamedSilentFail("VRecyclingE_Trash"), 1.05f),
+            // Other packs will get handled automatically due to no market value.
+        }
+        .Where(x => x.Item1 != null)
+        .ToDictionary(x => x.Item1, x => x.Item2);
 
     public override IEnumerable<Gizmo> CompGetGizmosExtra()
     {
@@ -78,7 +93,7 @@ public class CompSupplySlingshot : ThingComp
                 Map = parent.Map,
                 ReturnTick = Find.TickManager.TicksGame + TicksToReturn,
                 Wealth = compTransporter.innerContainer.Sum(item => item.MarketValue * item.stackCount),
-                ForcedItems =  forcedItems
+                ForcedItems = forcedItems
             });
             compTransporter.innerContainer.ClearAndDestroyContents();
             compTransporter.CancelLoad(parent.Map);
@@ -87,21 +102,35 @@ public class CompSupplySlingshot : ThingComp
     }
 
     // Make a method that will be easy to hook up into with harmony so other mods can go through and modify the contents,
-    // as well as add forced rewards. If someone will want to, they could add a whole bartering system with this.
+    // as well as add forced rewards. If someone wants to, they could add a whole bartering system with this.
     private static List<ThingDefStuffCount> AddForcedItems(ThingOwner container)
     {
-        var list = new List<ThingDefStuffCount>();
+        var entries = new Dictionary<(ThingDef thing, ThingDef stuff), float>();
 
-        if (ThingDefOf.Wastepack != null)
+        for (var i = container.Count - 1; i >= 0; i--)
         {
-            var totalWastePacks = container.TotalStackCountOfDef(ThingDefOf.Wastepack);
-            if (totalWastePacks > 0)
+            var item = container.GetAt(i);
+
+            // Return predefined items with a specified multiplier
+            if (ThingReturnCountMultiplier.TryGetValue(item.def, out var m))
+                AddCurrentToReturned(m);
+            // Return any item with no market value without modifying the stack count (minus rounding)
+            else if (item.MarketValue <= 0)
+                AddCurrentToReturned();
+
+            void AddCurrentToReturned(float multiplier = 1.0f)
             {
-                container.RemoveAll(t => t.def == ThingDefOf.Wastepack);
-                list.Add(new ThingDefStuffCount(ThingDefOf.Wastepack, Mathf.FloorToInt(totalWastePacks * 1.05f)));
+                var key = (item.def, item.Stuff);
+                var count = entries.TryGetValue(key) + item.stackCount * multiplier;
+                entries[key] = count;
+
+                container.RemoveAt(i);
             }
         }
 
-        return list;
+        return entries
+            .Select(x => new ThingDefStuffCount(x.Key.thing, x.Key.stuff, Mathf.Max(GenMath.RoundRandom(x.Value), 0)))
+            .Where(x => x.Count > 0)
+            .ToList();
     }
 }


### PR DESCRIPTION
To sum up the changes:
- Anything with no market value will be sent back
- All trash from VRE will be sent back
- The basic trash from VRE will send 5% extra, but nothing else

To be more precise with the changes:

Previously, supply slingshot was hardcoded to send back all toxic wastepacks back to the player (and give a 5% extra on top).

With the changes here, the toxic wastepacks are no longer hardcoded. Instead, anything that has a market value of 0 will be automatically sent back at a 1-to-1 ratio.

There's no extra being sent this time due to toxic wastepacks potentially being useful due to the ability to recycle them with Vanilla Recycling Expanded.

On top of that there's also a Dictionary of `ThingDef`s that will be sent back (regardless of market value), with the values of the dictionary being the multiplier that will be sent back to the player (if set to 0 then nothing will be sent back and no value will be gained). The VRE trash will return 5% extra since it's mostly worthless.

Other changes include adding `StaticConstructorOnStartup` (to setup the Dictionary) and the value of 60000 in `TicksToReturn` property was replaced with `GenDate.TicksPerDay` (to make the intent more clear here).