### PR TITLE
Fix the deterioration of uncontained super-nanites

### DIFF
--- a/Source/VFEAncients/HarmonyPatches/BuildingPatches.cs
+++ b/Source/VFEAncients/HarmonyPatches/BuildingPatches.cs
@@ -87,7 +87,7 @@ public static class BuildingPatches
     {
         if (t.TryGetComp<CompNeedsContainment>(out var comp) && comp.ShouldDeteriorate)
         {
-            __result += t.GetStatValue(StatDefOf.DeteriorationRate);
+            __result += StatDefOf.DeteriorationRate.Worker.GetBaseValueFor(StatRequest.For(t)) * 0.5f;
             reasons?.Add("VFEAncients.DeterioratingUncontained".Translate());
         }
     }


### PR DESCRIPTION
Super-nanites outside of proper containment were not having their deterioration rate increased unless the item was already deteriorating due to being outside or unroofed. The following line which is meant to increase the deterioration rate was pulling the finalized `DeteriorationRate` stat which was already finalized. This means that if the super-nanites were indoors and roofed, the  stat value would be `0`, and therefore this line of code was effectively doing `0 + 0`.

https://github.com/Vanilla-Expanded/VanillaFactionsExpanded-Ancients/blob/788c8b7ae482f916869273fcdb8550a14b7a4d6f/Source/VFEAncients/HarmonyPatches/BuildingPatches.cs#L90

This change retrieves the base value  for `DeteriorationRate` as defined in `VFEA_SuperNanites`, multiplies it by `0.5` to match the factors used by `factorOffsetUnroofed` and `factorOffsetOutside`, and then adds that to whatever the current finalized value for `DeteriorationRate` is for that item.

Since the base value for `DeteriorationRate` on the super-nanites is `20`, that means that the final rate of deterioration for super-nanites which are outside of proper containment, but otherwise protected by being indoors, roofed, and/or on a storage building that prevents deterioration, will still deteriorate at a rate of 10/day. 

Take those same super-nanites and toss them on the ground outside, and the rate of deterioration increases to 30/day.

Halving the base value when adding the additional deterioration qualifies as a balance change, so if that's undesirable just leave that out. Considering the usual state of the power grid in the vaults when you first spawn in and the time it takes to hack through the doors, I find it's too easy for you to lose all your super-nanites before you have a chance to even realize their containment units aren't powered because of unintended gaps in the power conduits. I feel like it gives players a fighting chance of saving their super-nanites without trivializing the need for containment.